### PR TITLE
chore: add github action CI to enforce main mr from dev branch only 

### DIFF
--- a/.github/workflows/validate-merge-branch.yml
+++ b/.github/workflows/validate-merge-branch.yml
@@ -1,0 +1,26 @@
+name: Enforce Merge from Dev to Main Only
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Log branches as debug info
+        run: |
+          echo "Base branch: ${{ github.base_ref }}"
+          echo "Head branch: ${{ github.head_ref }}"
+
+      - name: Fail if source branch is not 'dev'
+        if: github.head_ref != 'dev'
+        run: |
+          echo "❌ Merges to 'main' are only allowed from the 'dev' branch."
+          exit 1


### PR DESCRIPTION
…#23)

* chore: add github action CI to enforce main mr from dev branch only

* fix: move debug info before check fails

* fix: trigger also on synchronize and reopened pr