### PR TITLE
ci: add repository mirroring on Epitech eip repo

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -1,0 +1,18 @@
+name: Mirror Repository
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url: ${{ secrets.REPO_EPITECH_MIRROR }}
+          ssh_private_key: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
I made the mirroring target all branches instead of  the usual dev/main, let me know if that's okay for you
<img width="1306" height="684" alt="image" src="https://github.com/user-attachments/assets/70dde51f-cadc-4a19-a8db-a2db8f8e1024" />
