### PR TITLE
feat: generic logging system that does not impact run-time performances

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -23,6 +23,7 @@ option(ENABLE_COVERAGE "Enable coverage reporting" OFF)
 add_library(core STATIC
         src/binary/Binary.hpp
         src/utils/BeDecoder.hpp
+        src/utils/Logger.hpp
         src/exception/Exception.hpp
         src/exception/Exception.cpp
         src/binary/Loader.hpp
@@ -59,6 +60,10 @@ target_include_directories(core PUBLIC
 target_link_libraries(core PRIVATE ${ZLIB_LIBRARIES})
 
 target_compile_features(core PUBLIC cxx_std_20)
+
+# Log level: 0=Trace 1=Debug 2=Info 3=Warning 4=Error 5=None (default: 4)
+set(WEMU_LOG_LEVEL "4" CACHE STRING "Compile-time log level (0=Trace, 1=Debug, 2=Info, 3=Warning, 4=Error, 5=None)")
+target_compile_definitions(core PUBLIC WEMU_LOG_LEVEL=${WEMU_LOG_LEVEL})
 
 if(ENABLE_COVERAGE)
     target_compile_options(core PRIVATE --coverage -O0 -g)

--- a/core/src/cpu/interpreter/Interpreter.cpp
+++ b/core/src/cpu/interpreter/Interpreter.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "Interpreter.hpp"
+#include "utils/Logger.hpp"
 
 Core::Interpreter::Interpreter(Core::Binary binary) : m_binary(std::move(binary)) { initInstructionMap(); }
 
@@ -17,13 +18,13 @@ Core::Interpreter::Interpreter(Core::Binary binary) : m_binary(std::move(binary)
 {
     decoder.seek(m_pc);
     const EncodedInstruction encodedInstruction(decoder.extractSwap<std::uint32_t>());
-    std::cout << std::format("[PC=0x{:08X}]\t", ppc_pc) << std::bitset<32>(encodedInstruction.raw) << "\t";
+    Utils::Log::trace("[PC=0x{:08X}]\t{}", ppc_pc, std::bitset<32>(encodedInstruction.raw).to_string());
     m_nextPc = m_pc + Core::INSTR_SIZE;
     try {
         executeInstruction(encodedInstruction);
         debugDumpGPR();
     } catch (Core::Exception &e) {
-        std::cout << std::format("[PC=0x{:08X}] {}", ppc_pc, e.what()) << std::endl;
+        Utils::Log::error("[PC=0x{:08X}] {}", ppc_pc, e.what());
         if (e.isFatal())
             return false;
     }
@@ -36,14 +37,14 @@ void Core::Interpreter::run()
     std::uint32_t ppc_pc = m_binary.header.e_entry;
 
     m_pc = ppc_pc - Core::Memory::MemoryMap::ApplicationCode;
-    std::cout << std::format("[EMU] Starting at entrypoint 0x{:08X}", ppc_pc) << std::endl;
+    Utils::Log::info("[EMU] Starting at entrypoint 0x{:08X}", ppc_pc);
     while (true) {
         ppc_pc = m_pc + Core::Memory::MemoryMap::ApplicationCode;
         if (!step(instructionDecoder, ppc_pc))
             break;
         m_pc = m_nextPc;
     }
-    std::cout << std::format("[EMU] Exited. PC=0x{:08X}", ppc_pc) << std::endl;
+    Utils::Log::info("[EMU] Exited. PC=0x{:08X}", ppc_pc);
 }
 
 InstructionID Core::Interpreter::findInstructionID(const EncodedInstruction &instr)
@@ -80,7 +81,7 @@ void Core::Interpreter::executeInstruction(const EncodedInstruction &instr)
 {
     InstructionID id = findInstructionID(instr);
 
-    std::cout << instructionIDToString(id) << std::endl;
+    Utils::Log::trace("{}", instructionIDToString(id));
     INSTRUCTIONARRAY[id].function(*this, instr);
 }
 

--- a/core/src/cpu/interpreter/Interpreter.hpp
+++ b/core/src/cpu/interpreter/Interpreter.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <cstdint>
-#include <iomanip>
 #include <map>
+#include <print>
 #include <stdfloat>
 #include <vector>
 
@@ -19,6 +19,7 @@
 #include "cpu/types/EncodedInstruction.hpp"
 #include "cpu/types/Instruction.hpp"
 #include "utils/BeDecoder.hpp"
+#include "utils/Logger.hpp"
 
 namespace Core {
     static constexpr std::uint32_t INSTR_SIZE = sizeof(std::uint32_t);
@@ -50,21 +51,12 @@ namespace Core {
 
             void debugDumpGPR() const
             {
-                std::ios oldState(nullptr);
-                oldState.copyfmt(std::cout);
-
-                std::cout << "==== GPR Dump ====\n";
-
-                for (int i = 0; i < 32; ++i) {
-                    std::cout
-                        << "r" << std::setw(2) << std::setfill('0') << i << " : "
-                        << "0x" << std::hex << std::setw(8) << std::setfill('0') << m_gpr[i]
-                        << "  (" << std::dec << m_gprSigned[i] << ")\n";
+                if constexpr (Utils::Log::kLevel <= Utils::Log::Level::Trace) {
+                    std::println("==== GPR Dump ====");
+                    for (int i = 0; i < 32; ++i)
+                        std::println("r{:02d} : 0x{:08X}  ({})", i, m_gpr[i], m_gprSigned[i]);
+                    std::println("==================");
                 }
-
-                std::cout << "==================\n";
-
-                std::cout.copyfmt(oldState);
             }
 
             void reset()

--- a/core/src/utils/Logger.hpp
+++ b/core/src/utils/Logger.hpp
@@ -1,0 +1,71 @@
+/*
+** EPITECH PROJECT, 2025
+** core
+** File description:
+** Logger
+*/
+
+#pragma once
+
+#include <format>
+#include <print>
+#include <string_view>
+
+namespace Utils::Log {
+
+enum class Level : int {
+    Trace   = 0,
+    Debug   = 1,
+    Info    = 2,
+    Warning = 3,
+    Error   = 4,
+    None    = 5,
+};
+
+#ifndef WEMU_LOG_LEVEL
+    #define WEMU_LOG_LEVEL 4
+#endif
+
+inline constexpr Level kLevel = static_cast<Level>(WEMU_LOG_LEVEL);
+
+namespace detail {
+    consteval std::string_view prefix(Level l) noexcept
+    {
+        switch (l) {
+            case Level::Trace:   return "[TRACE] ";
+            case Level::Debug:   return "[DEBUG] ";
+            case Level::Info:    return "[INFO]  ";
+            case Level::Warning: return "[WARN]  ";
+            case Level::Error:   return "[ERROR] ";
+            default:             return "[?????] ";
+        }
+    }
+} // namespace detail
+
+template<Level L, typename... Args>
+inline void log(std::format_string<Args...> fmt, Args&&... args)
+{
+    if constexpr (L >= kLevel) {
+        if constexpr (L >= Level::Warning)
+            std::println(stderr, "{}{}", detail::prefix(L), std::format(fmt, std::forward<Args>(args)...));
+        else
+            std::println("{}{}", detail::prefix(L), std::format(fmt, std::forward<Args>(args)...));
+    }
+}
+
+template<typename... Args>
+void trace(std::format_string<Args...> f, Args&&... a) { log<Level::Trace>  (f, std::forward<Args>(a)...); }
+
+template<typename... Args>
+void debug(std::format_string<Args...> f, Args&&... a) { log<Level::Debug>  (f, std::forward<Args>(a)...); }
+
+template<typename... Args>
+void info(std::format_string<Args...> f, Args&&... a)  { log<Level::Info>   (f, std::forward<Args>(a)...); }
+
+template<typename... Args>
+void warn(std::format_string<Args...> f, Args&&... a)  { log<Level::Warning>(f, std::forward<Args>(a)...); }
+
+template<typename... Args>
+void error(std::format_string<Args...> f, Args&&... a) { log<Level::Error>  (f, std::forward<Args>(a)...); }
+
+} // namespace Utils::Log


### PR DESCRIPTION
Closes #197

Add `Utils::Log` — a header-only logger with compile-time levels (Trace, Debug, Info, Warning, Error) controlled via `-DWEMU_LOG_LEVEL` cmake param.

Disabled levels generate zero code: `if constexpr` on a `constexpr` constant guarantees the compiler elides the branch entirely.

Default: Error only. Migrate `Interpreter.cpp/hpp` to use it.